### PR TITLE
Improve output and log handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,10 @@ Style/SpecialGlobalVars:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - "**/*_spec.rb"
+
 Metrics/MethodLength:
   Enabled: false
 

--- a/fastlane-plugin-clang_analyzer.gemspec
+++ b/fastlane-plugin-clang_analyzer.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = %q{Sergei_Fedortsov@cedoni.com}
 
   spec.summary       = %q{Runs Clang Static Analyzer(http://clang-analyzer.llvm.org/) and generates report}
- spec.homepage      = "https://github.com/SiarheiFedartsou/fastlane-plugin-clang_analyzer"
+  spec.homepage      = "https://github.com/SiarheiFedartsou/fastlane-plugin-clang_analyzer"
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'xcpretty'
   spec.add_development_dependency 'fastlane', '>= 1.104.0'
 end

--- a/spec/clang_analyzer_action_spec.rb
+++ b/spec/clang_analyzer_action_spec.rb
@@ -9,10 +9,14 @@ describe Fastlane::Actions::ClangAnalyzerAction do
         " -sdk iphonesimulator" \
         " -arch i386" \
         " clean" \
-        " analyze"
+        " analyze" \
+        " | tee /log_file_path" \
+        " | xcpretty"
 
       fake_output = File.read('./spec/fixtures/scan-build_output_fixture')
-      expect(Fastlane::Actions).to receive(:sh).with(expected_command).and_return(fake_output)
+      expect(FastlaneCore::CommandExecutor).to receive(:execute).with(hash_including(command: expected_command))
+      expect(File).to receive(:read).with('/log_file_path').and_return(fake_output)
+      allow(FileUtils).to receive(:mkdir_p) {}
       expect(FileUtils).to receive(:rm_rf).with('/report_output_path')
       expect(FileUtils).to receive(:cp_r).with('/var/folders/fake_report_path', '/report_output_path')
 
@@ -21,6 +25,7 @@ describe Fastlane::Actions::ClangAnalyzerAction do
               scheme: 'TestScheme',
               analyzer_path: '/analyzer/bin',
               configuration: 'Debug',
+              log_file_path: '/log_file_path',
               report_output_path: '/report_output_path')
       end").runner.execute(:test)
     end
@@ -34,10 +39,14 @@ describe Fastlane::Actions::ClangAnalyzerAction do
         " -sdk iphonesimulator" \
         " -arch i386" \
         " clean" \
-        " analyze"
+        " analyze" \
+        " | tee /log_file_path" \
+        " | xcpretty"
 
       fake_output = File.read('./spec/fixtures/scan-build_output_fixture_no_bugs')
-      expect(Fastlane::Actions).to receive(:sh).with(expected_command).and_return(fake_output)
+      expect(FastlaneCore::CommandExecutor).to receive(:execute).with(hash_including(command: expected_command))
+      expect(File).to receive(:read).with('/log_file_path').and_return(fake_output)
+      allow(FileUtils).to receive(:mkdir_p) {}
       expect(FileUtils).to receive(:rm_rf).with('/report_output_path')
       expect(FileUtils).not_to receive(:cp_r)
 
@@ -46,6 +55,7 @@ describe Fastlane::Actions::ClangAnalyzerAction do
               scheme: 'TestScheme',
               analyzer_path: '/analyzer/bin',
               configuration: 'Debug',
+              log_file_path: '/log_file_path',
               report_output_path: '/report_output_path')
       end").runner.execute(:test)
     end


### PR DESCRIPTION
- Add clean option to be able to run faster analyzer builds
- Use xcpretty and CommandExecutor instead of Action.sh to have output similar to gym and scan
- Add new log file path to store raw xcodebuild output
- FileUtils.rm_rf does not throw exception, so no need to rescue
- Change default output path
  - Fastlane setup allows both 'fastlane' and '.fastlane' directory names, so better use another default
- Make sure output directory is created with mkdir_p

Fixes: https://github.com/SiarheiFedartsou/fastlane-plugin-clang_analyzer/issues/1